### PR TITLE
Fix license

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "hot reload",
     "webpack"
   ],
-  "license": "AGPLv3",
+  "license": "AGPL-3.0",
   "devDependencies": {
     "babel-core": "^6.3.15",
     "babel-eslint": "^7.1.0",


### PR DESCRIPTION
This fixes the next warning:
```
npm WARN heutagogy-chrome-extension@0.1.0 license should be a valid SPDX license expression
```