### PR TITLE
Inline TWO in scripts/compress.js

### DIFF
--- a/scripts/compress.js
+++ b/scripts/compress.js
@@ -1,10 +1,8 @@
-import TWO from '../app/constants/Constants';
-
 const fs = require('fs'); //eslint-disable-line
 const ChromeExtension = require('crx'); //eslint-disable-line
 /* eslint import/no-unresolved: 0 */
 const name = require('../build/manifest.json').name; //eslint-disable-line
-const argv = require('minimist')(process.argv.slice(TWO)); //eslint-disable-line
+const argv = require('minimist')(process.argv.slice(2)); //eslint-disable-line
 
 const keyPath = argv.key || 'key.pem';
 const existsKey = fs.existsSync(keyPath); //eslint-disable-line


### PR DESCRIPTION
Problem:
```
[nix-shell:~/prg/heutagogy-chrome-extension]$ npm run compress

> heutagogy-chrome-extension@0.1.0 compress /home/rasen/prg/heutagogy-chrome-extension
> node scripts/compress

/home/rasen/prg/heutagogy-chrome-extension/scripts/compress.js:1
(function (exports, require, module, __filename, __dirname) { import TWO from '../app/constants/Constants';
                                                              ^^^^^^
SyntaxError: Unexpected token import
    at Object.exports.runInThisContext (vm.js:76:16)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```