### PR TITLE
Request more bookmarks from the server

### DIFF
--- a/app/actions/entity.js
+++ b/app/actions/entity.js
@@ -19,7 +19,7 @@ const fetchEntities = () => ({
       { type: LOAD_ENTITIES_FAILURE },
     ],
     method: 'GET',
-    endpoint: `${API_VERSION}/bookmarks`,
+    endpoint: `${API_VERSION}/bookmarks?per_page=200`,
   },
 });
 

--- a/app/utils/loader.js
+++ b/app/utils/loader.js
@@ -3,7 +3,7 @@ import article from '../schemas/article';
 
 export const loadEntities = (store) => {
   load({
-    href: '/bookmarks',
+    href: '/bookmarks?per_page=200',
     schema: article,
   })(store.dispatch);
 };


### PR DESCRIPTION
Problem: I have more than 20 bookmarks, and extension behaviour is
unpredictable.

Solution: Request more bookmarks in one request. This is a workaround,
but should for now.