### PR TITLE
Remove vertical scroll bar for 1219×653 Google Chrome viewport size

### DIFF
--- a/app/components/LoginForm/LoginForm.js
+++ b/app/components/LoginForm/LoginForm.js
@@ -29,7 +29,7 @@ const inlineStyles = {
   statusDiv: {
     height: '30px',
     textAlign: 'center',
-    margin: '7px 0 35px 0',
+    margin: '5px 0 30px 0',
   },
   statusMessage: {
     fontSize: '14px',

--- a/app/components/LoginForm/LoginForm.less
+++ b/app/components/LoginForm/LoginForm.less
@@ -12,5 +12,5 @@
 }
 
 .login {
-  margin: 65px 0 35px 0;
+  margin: 65px 0 28px 0;
 }


### PR DESCRIPTION
Turn this:
![selection_032](https://cloud.githubusercontent.com/assets/6199462/22473517/7809a980-e7d9-11e6-8917-42adbe5de950.jpg)
into this:
![selection_031](https://cloud.githubusercontent.com/assets/6199462/22473544/8a8623cc-e7d9-11e6-8a15-480a98a06ed4.jpg)
