### PR TITLE
Index articles by current url.

### DIFF
--- a/app/actions/article.js
+++ b/app/actions/article.js
@@ -29,7 +29,8 @@ export const REMOVE_ARTICLE_FAILURE = 'REMOVE_ARTICLE_FAILURE';
 
 
 const postRememberArticle = ({ article }) => {
-  const meta = { viewId: REMEMBER_ARTICLE_VIEW_STATE, article };
+  const articleUrl = article.get('url');
+  const meta = { viewId: REMEMBER_ARTICLE_VIEW_STATE, articleUrl };
 
   return {
     [CALL_API]: {
@@ -50,7 +51,7 @@ const postRememberArticle = ({ article }) => {
 };
 
 const postUpdateArticle = (articleId, articleFields) => {
-  const meta = { viewId: UPDATE_ARTICLE_VIEW_STATE, articleId, articleFields };
+  const meta = { viewId: UPDATE_ARTICLE_VIEW_STATE, articleId };
 
   return {
     [CALL_API]: {
@@ -71,7 +72,7 @@ const postUpdateArticle = (articleId, articleFields) => {
 };
 
 const getArticleByUrl = (articleUrl) => {
-  const meta = { viewId: FETCH_ARTICLE_VIEW_STATE };
+  const meta = { viewId: FETCH_ARTICLE_VIEW_STATE, articleUrl };
   const encodedURI = encodeURIComponent(articleUrl);
 
   return {

--- a/app/reducers/entityReducers/article.js
+++ b/app/reducers/entityReducers/article.js
@@ -1,5 +1,3 @@
-/* eslint-disable fp/no-let */
-/* eslint-disable fp/no-mutation */
 import {
   REMEMBER_ARTICLE_SUCCESS,
   UPDATE_ARTICLE_SUCCESS,
@@ -10,30 +8,30 @@ import {
 
 export default (state, action) => {
   switch (action.type) {
-    case REMEMBER_ARTICLE_SUCCESS:
-    case UPDATE_ARTICLE_SUCCESS: {
-      const article = action.payload.getIn(['entities', 'article']);
-      const newState = state.mergeIn(['article'], article);
-
-      return newState;
-    }
     case LOAD_ARTICLE_SUCCESS: {
-      const entities = action.payload.get('entities');
+      const articles = action.payload.getIn(['entities', 'article']);
 
-      let result = state;
+      if (!articles) {
+        return state;
+      }
 
-      entities.forEach((theEntities, entityType) => {
-        theEntities.forEach((entity, entityId) => {
-          result = result.mergeIn([entityType, entityId], entity);
-        });
-      });
+      return state.setIn(['article', action.meta.articleUrl], articles.first());
+    }
+    case REMEMBER_ARTICLE_SUCCESS: {
+      const article = action.payload.getIn(['entities', 'article']).first();
 
-      return result;
+      return state.setIn(['article', action.meta.articleUrl], article);
+    }
+    case UPDATE_ARTICLE_SUCCESS: {
+      const article = action.payload.getIn(['entities', 'article']).first();
+      const articleUrl = state.getIn(['article']).findKey((el) => el.get('id') === action.meta.articleId);
+
+      return state.setIn(['article', articleUrl], article);
     }
     case REMOVE_ARTICLE_SUCCESS: {
-      const article = state.getIn(['article']).find((el) => el.get('id') === action.meta.articleId);
+      const articleUrl = state.getIn(['article']).findKey((el) => el.get('id') === action.meta.articleId);
 
-      return state.deleteIn(['article', article.get('url')]);
+      return state.deleteIn(['article', articleUrl]);
     }
     default: {
       return state;


### PR DESCRIPTION
Problem: status of articles containing anchor are not properly detected by
extension.

Reason: server strips the anchor from each url, extension indexes articles by
url from server and uses current url for checking article statuses on the popup.

Solution: index articles by current url.