### PR TITLE
Skip cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_deploy:
 - npm run compress
 deploy:
   provider: script
+  skip_cleanup: true
   script: npm run webstore-upload
   on:
     repo: heutagogy/heutagogy-chrome-extension


### PR DESCRIPTION
Problem:
```
Error: Cannot find module 'adm-zip'
```

Solution: I believe this is caused by cleanup called before deploying,
so it just deleted most of the files produced during the build. Even
if that is not the case, we still want to skip cleanup as we're
uploading build artifacts.