### PR TITLE
Don't fetch tab status if not logged in

### DIFF
--- a/app/components/LoginForm/LoginForm.js
+++ b/app/components/LoginForm/LoginForm.js
@@ -134,7 +134,7 @@ const mapStateToProps = (state) => {
     user: getUser(state),
     options: getOptions(state),
     initialValues: {
-      server: getOptions(state).get('serverAddress') || 'https://heutagogy.herokuapp.com',
+      server: getOptions(state).get('serverAddress'),
     },
   });
 };

--- a/app/reducers/options.js
+++ b/app/reducers/options.js
@@ -7,6 +7,7 @@ import { saveOptions } from './../utils/localStorageUtils';
 
 const initialState = Immutable.fromJS({
   authUser: {},
+  serverAddress: 'https://heutagogy.herokuapp.com',
 });
 
 export default (state = initialState, action) => {

--- a/chrome/extension/background.js
+++ b/chrome/extension/background.js
@@ -6,6 +6,8 @@ import { handleRememberArticle, handleReadArticle } from '../../app/utils/keyBin
 import { tabHandler } from './background/icon';
 import { getArticle } from './../../app/selectors/article';
 import { initTabTracker, getTabs, getTab } from './../../app/modules/tabsTracker';
+import { getUser } from './../../app/selectors/user';
+import { isLoggedIn } from './../../app/utils/userUtils';
 
 global.Promise = bluebird; //eslint-disable-line
 
@@ -67,7 +69,8 @@ chrome.storage.local.get('state', (obj) => {
       const url = tab.get('url');
       const oldTab = getTab(oldVal, tabId);
 
-      if (url !== oldTab.get('url') ||
+      if (isLoggedIn(getUser(newVal)) !== isLoggedIn(getUser(oldVal)) ||
+          url !== oldTab.get('url') ||
           tab.get('status') !== oldTab.get('status') ||
           !getArticle(newVal, url).equals(getArticle(oldVal, url))) {
         tabHandler(store)(tabId, url);

--- a/chrome/extension/background/icon.js
+++ b/chrome/extension/background/icon.js
@@ -11,31 +11,39 @@ import icon16Saved from './../../assets/img/icon-16-saved.png';
 import icon32Saved from './../../assets/img/icon-32-saved.png';
 import icon128Saved from './../../assets/img/icon-128-saved.png';
 
+const setBadge = (tabId, saved, read) => {
+  if (saved) {
+    chrome.browserAction.setIcon({
+      path: { 16: icon16Saved, 32: icon32Saved, 128: icon128Saved },
+      tabId,
+    });
+  } else {
+    chrome.browserAction.setIcon({
+      path: { 16: icon16, 32: icon32, 128: icon128 },
+      tabId,
+    });
+  }
+
+  if (read) {
+    chrome.browserAction.setBadgeBackgroundColor({ color: '#ff4081', tabId });
+    chrome.browserAction.setBadgeText({ text: ' ', tabId });
+  } else {
+    chrome.browserAction.setBadgeText({ text: '', tabId });
+  }
+};
+
 export const tabHandler = (store) => (tabId, url) => {
-  store.dispatch(fetchArticleByUrl(url)).then(() => {
-    const state = store.getState();
-    const article = getArticle(state, url);
-    const user = getUser(state);
+  const state = store.getState();
+  const user = getUser(state);
 
-    if (isLoggedIn(user)) {
-      if (article.get('read')) {
-        chrome.browserAction.setBadgeBackgroundColor({ color: '#ff4081', tabId });
-        chrome.browserAction.setBadgeText({ text: ' ', tabId });
-      } else {
-        chrome.browserAction.setBadgeText({ text: '', tabId });
-      }
+  if (isLoggedIn(user)) {
+    setBadge(tabId, false, false);
+    store.dispatch(fetchArticleByUrl(url)).then(() => {
+      const article = getArticle(state, url);
 
-      if (article.get('id')) {
-        chrome.browserAction.setIcon({
-          path: { 16: icon16Saved, 32: icon32Saved, 128: icon128Saved },
-          tabId,
-        });
-      } else {
-        chrome.browserAction.setIcon({
-          path: { 16: icon16, 32: icon32, 128: icon128 },
-          tabId,
-        });
-      }
-    }
-  });
+      setBadge(tabId, article.get('id'), article.get('read'));
+    });
+  } else {
+    setBadge(tabId, false, false);
+  }
 };

--- a/chrome/extension/background/icon.js
+++ b/chrome/extension/background/icon.js
@@ -37,12 +37,13 @@ export const tabHandler = (store) => (tabId, url) => {
   const user = getUser(state);
 
   if (isLoggedIn(user)) {
-    setBadge(tabId, false, false);
-    store.dispatch(fetchArticleByUrl(url)).then(() => {
-      const article = getArticle(state, url);
+    const article = getArticle(state, url);
 
-      setBadge(tabId, article.get('id'), article.get('read'));
-    });
+    setBadge(tabId, article.get('id'), article.get('read'));
+
+    if (!article.get('url')) {
+      store.dispatch(fetchArticleByUrl(url));
+    }
   } else {
     setBadge(tabId, false, false);
   }


### PR DESCRIPTION
Problem: when user is not logged in, all requests are destined to
fail. Also, the server is not set yet, which is another source of the
errors.

Solution: only do requests when user is already logged in.