### PR TITLE
Fix popup updates when url changes

### DIFF
--- a/app/reducers/entityReducers/article.js
+++ b/app/reducers/entityReducers/article.js
@@ -24,14 +24,14 @@ export default (state, action) => {
     }
     case UPDATE_ARTICLE_SUCCESS: {
       const article = action.payload.getIn(['entities', 'article']).first();
-      const articleUrl = state.getIn(['article']).findKey((el) => el.get('id') === action.meta.articleId);
 
-      return state.setIn(['article', articleUrl], article);
+      return state.update('article', (articles) =>
+                          articles.map((v) =>
+                                       (v.get('id') === action.meta.articleId ? article : v)));
     }
     case REMOVE_ARTICLE_SUCCESS: {
-      const articleUrl = state.getIn(['article']).findKey((el) => el.get('id') === action.meta.articleId);
-
-      return state.deleteIn(['article', articleUrl]);
+      return state.update('article', (articles) =>
+                          articles.filter((v) => v.get('id') !== action.meta.articleId));
     }
     default: {
       return state;


### PR DESCRIPTION
Problem: when the article changes url once (medium.com), popup is not
able to report article status immediately.

Cause: the issue was caused by entities reducer to update only one
article (in non-deterministic fashion).

Solution: this commit makes entities reducer update all entries with
the matching id.