### PR TITLE
Properly handle deleted articles

### DIFF
--- a/app/reducers/entityReducers/article.js
+++ b/app/reducers/entityReducers/article.js
@@ -12,7 +12,7 @@ export default (state, action) => {
       const articles = action.payload.getIn(['entities', 'article']);
 
       if (!articles) {
-        return state;
+        return state.deleteIn(['article', action.meta.articleUrl]);
       }
 
       return state.setIn(['article', action.meta.articleUrl], articles.first());


### PR DESCRIPTION
Problem: extension does not detect deletion when article was removed
from the frontend. This leads to multiple additional issues with the
page: it is always reported as saved, impossibe to read or save
again.

Cause: the issue was caused by extension ignoring empty answers,
while in reality they mean there is no article for given url.

Solution: when empty response arrives, delete article for given url.